### PR TITLE
ドメインの所有権確認用のタグを追加した

### DIFF
--- a/app/views/application/_google_site_verification.html.erb
+++ b/app/views/application/_google_site_verification.html.erb
@@ -1,0 +1,1 @@
+<meta name="google-site-verification" content="sv8XK0XTxYTLDJosjZxF_O_cZUYeTsl3UuVpQYm_dSM" />

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -9,7 +9,9 @@ html
     = favicon_link_tag '/favicon.svg'
     = stylesheet_link_tag 'application', 'data-turbo-track': 'reload'
     = javascript_include_tag 'application', 'data-turbo-track': 'reload', defer: true
-    = render 'google_tag_manager' if Rails.env.production?
+    - if Rails.env.production?
+      = render 'google_tag_manager'
+      = render 'google_site_verification'
   body
     = render 'header'
     main


### PR DESCRIPTION
GTMでの所有権確認が通らないため