### PR TITLE
showのリンクを表示する条件を変更

### DIFF
--- a/app/views/fingerings/show.html.slim
+++ b/app/views/fingerings/show.html.slim
@@ -4,12 +4,13 @@
   - else
     = content_tag(:p, '非公開の指板図です')
 
-  .no-print.d-flex.flex-wrap.justify-content-between.align-items-center.py-3.my-4.border-top
-    .col-md-4.d-flex.align-items-center
-      - if @fingering.created_by?(current_user)
+  - if logged_in?
+    .no-print.d-flex.flex-wrap.justify-content-between.align-items-center.py-3.my-4.border-top
+      .col-md-4.d-flex.align-items-center
+        - if @fingering.created_by?(current_user)
+          .mb-3.me-2.mb-md-0.text-body-secondary
+            = link_to '編集', edit_fingering_path(@fingering)
+          .mb-3.me-2.mb-md-0.text-body-secondary
+            = link_to '削除', @fingering, data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか？' }
         .mb-3.me-2.mb-md-0.text-body-secondary
-          = link_to '編集', edit_fingering_path(@fingering)
-        .mb-3.me-2.mb-md-0.text-body-secondary
-          = link_to '削除', @fingering, data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか？' }
-      .mb-3.me-2.mb-md-0.text-body-secondary
-        = link_to '一覧に戻る', fingerings_path
+          = link_to '一覧に戻る', fingerings_path

--- a/spec/system/fingerings_spec.rb
+++ b/spec/system/fingerings_spec.rb
@@ -52,6 +52,18 @@ RSpec.describe 'Fingerings', type: :system, js: true do
         expect(page).to have_current_path fingering_path(fingering)
         expect(page).to have_selector '.konvajs-content'
       end
+
+      it 'does not display edit link for others fingerings' do
+        sign_in_as(other_user)
+        visit fingering_path(public_fingering)
+        expect(page).to have_no_content '編集'
+      end
+
+      it 'does not display destroy link for others fingerings' do
+        sign_in_as(other_user)
+        visit fingering_path(public_fingering)
+        expect(page).to have_no_content '削除'
+      end
     end
 
     context 'when update' do
@@ -111,6 +123,7 @@ RSpec.describe 'Fingerings', type: :system, js: true do
         expect(public_fingering.is_public).to be true
         visit fingering_path(public_fingering)
         expect(page).to have_selector '.konvajs-content'
+        expect(page).to have_no_content '一覧へ戻る'
       end
 
       it 'does not display private fingerings' do


### PR DESCRIPTION
- #157 

- 非ログインの時は一覧へのリンクを表示しないようにした
- 自分の指板図であるかどうかに関わらずログインユーザーであれば編集、削除リンクが表示されていたため、自分の指板図の場合のみ表示されるようにした