### PR TITLE
flyioの初期ドメインへのアクセスを独自ドメインにリダイレクトするようにした

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,8 @@
 Rails.application.routes.draw do
+  constraints host: 'guitar-scale-sketch.fly.dev' do
+    get '/(*path)', to: redirect { |path_params,| "https://guitar-scale-sketch.com/#{path_params[:path]}" }
+  end
+
   get 'welcome/index'
   get 'privacy_policy', to: 'welcome#privacy_policy'
   get 'tos', to: 'welcome#tos'


### PR DESCRIPTION
- flyioと独自ドメインでのコンテンツの重複はなるべく避けた方がよさそうなので
- 初期ドメインを無効にする方法はなさそうなので、アプリ側でリダイレクトすることにした
    - [Is it possible to disable the fly\.dev subdomain for an app? \- Questions / Help \- Fly\.io](https://community.fly.io/t/is-it-possible-to-disable-the-fly-dev-subdomain-for-an-app/5863)
- [ドメイン名変更時のリダイレクトを Rails のルーティングで設定する](https://zenn.dev/fuji_nakahara/articles/23257b0f4b0b8e)