### PR TITLE
印刷しない要素の指定にBootstrapのクラスを使うようにした

### DIFF
--- a/app/assets/stylesheets/_print.scss
+++ b/app/assets/stylesheets/_print.scss
@@ -8,9 +8,6 @@
     width: 1320px;
     zoom: 0.8;
   }
-  .no-print {
-    display: none;
-  }
   .print-target {
     display: flex;
     justify-content: center;

--- a/app/views/application/_footer.html.slim
+++ b/app/views/application/_footer.html.slim
@@ -1,4 +1,4 @@
-footer.pt-3.border-top.no-print
+footer.pt-3.border-top.d-print-none
   .container
     ul.nav.justify-content-center.pb-0
       li.nav-item

--- a/app/views/application/_header.html.slim
+++ b/app/views/application/_header.html.slim
@@ -1,4 +1,4 @@
-header.p-3.mb-3.border-bottom.no-print
+header.p-3.mb-3.border-bottom.d-print-none
   .container
     .d-flex.flex-wrap.align-items-center.justify-content-center.justify-content-lg-start
       = link_to root_path, class: 'd-flex align-items-center mb-2 mb-lg-0 text-dark text-decoration-none'

--- a/app/views/fingerings/_form.html.slim
+++ b/app/views/fingerings/_form.html.slim
@@ -1,6 +1,6 @@
 div data-controller="fingering-form"
   = bootstrap_form_with(model: fingering, class: '') do |f|
-    .sticky-top.card.w-75.m-3.p-1.no-print
+    .sticky-top.card.w-75.m-3.p-1.d-print-none
       .pt-2.px-2
         = f.text_field :title, data: { fingering_form_target: 'title' }
         = f.hidden_field :fingering_code, data: { fingering_form_target: 'output' }

--- a/app/views/fingerings/new.html.slim
+++ b/app/views/fingerings/new.html.slim
@@ -1,6 +1,6 @@
 .fingering-container
   .container.d-none.d-lg-block.d-print-inline
-    h1.no-print.fs-4
+    h1.d-print-none.fs-4
       | 指板図をつくる
     = render 'form', fingering: @fingering
   .container.d-block.d-lg-none.d-print-none

--- a/app/views/fingerings/show.html.slim
+++ b/app/views/fingerings/show.html.slim
@@ -5,7 +5,7 @@
     = content_tag(:p, '非公開の指板図です')
 
   - if logged_in?
-    .no-print.d-flex.flex-wrap.justify-content-between.align-items-center.py-3.my-4.border-top
+    .d-print-none.d-flex.flex-wrap.justify-content-between.align-items-center.py-3.my-4.border-top
       .col-md-4.d-flex.align-items-center
         - if @fingering.created_by?(current_user)
           .mb-3.me-2.mb-md-0.text-body-secondary


### PR DESCRIPTION
- #169 